### PR TITLE
Animate header highlighter

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -35,12 +35,23 @@ img,svg,video{max-width:100%;height:auto}
 
 /* Header highlight over “can’t read” */
 .hero__title .hl{
-  position:relative;display:inline-block;padding:0 .15em;border-radius:.25em;transition:color .2s;
+  position:relative;
+  display:inline-block;
+  padding:0 .15em;
+  border-radius:.25em;
+  transition:color .2s 200ms;
 }
 .hero__title .hl .sweep{
-  position:absolute;inset:0;background:var(--accent);
-  transform-origin:left;transform:scaleX(0);
-  border-radius:.25em;z-index:-1;
+  position:absolute;
+  left:0;
+  right:0;
+  bottom:0;
+  height:.55em;
+  background:var(--accent);
+  transform-origin:left;
+  transform:scaleX(0);
+  border-radius:.25em;
+  z-index:-1;
 }
 .animate-hl .hero__title .hl{ color:#111; }
 .animate-hl .hero__title .hl .sweep{


### PR DESCRIPTION
## Summary
- animate a red sweep beneath "can't read" in hero header
- delay color transition to sync with sweep animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689a71961f30832ca7e3e1717fcc5948