### PR TITLE
Animate header highlighter

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -39,23 +39,31 @@ img,svg,video{max-width:100%;height:auto}
   display:inline-block;
   padding:0 .15em;
   border-radius:.25em;
-  background:linear-gradient(var(--accent),var(--accent)) 0 100%/0 0.55em no-repeat;
-  transition:color .2s 200ms, background-size 1200ms cubic-bezier(.22,1,.36,1) 200ms;
+  transition:color .2s 200ms;
+  z-index:0;
 }
-.animate-hl .hero__title .hl{
-  color:#111;
-  background-size:100% 0.55em;
+.hero__title .hl .sweep{
+  position:absolute;
+  left:0;
+  right:0;
+  bottom:0;
+  height:.55em;
+  background:var(--accent);
+  transform-origin:left;
+  transform:scaleX(0);
+  border-radius:.25em;
+  z-index:-1;
+  transition:transform 1200ms cubic-bezier(.22,1,.36,1) 200ms;
 }
+.animate-hl .hero__title .hl{color:#111;}
+.animate-hl .hero__title .hl .sweep{transform:scaleX(1);}
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce){
   .hero__video{display:none}
   .section-title:after{animation:none}
-  .animate-hl .hero__title .hl{
-    transition:none;
-    background-size:100% 0.55em;
-    color:#111;
-  }
+  .animate-hl .hero__title .hl{transition:none;color:#111;}
+  .animate-hl .hero__title .hl .sweep{transition:none;transform:scaleX(1);}
 }
 
 /* Panels */

--- a/js/app.js
+++ b/js/app.js
@@ -58,7 +58,7 @@ const spendColor = thresholdScale(SPEND_THRESHOLDS, COLORS);
   const txt = h2.textContent;
   const target = /can't read/i;
   if (!target.test(txt)) return;
-  h2.innerHTML = txt.replace(target, (m)=>`<span class="hl">${m}</span>`);
+  h2.innerHTML = txt.replace(target, (m)=>`<span class="hl"><span class="sweep"></span>${m}</span>`);
   // trigger animation after a tick
   requestAnimationFrame(()=> document.documentElement.classList.add("animate-hl"));
 })();


### PR DESCRIPTION
## Summary
- animate a red sweep beneath "can't read" in hero header
- create stacking context so the sweep renders behind the text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689a71961f30832ca7e3e1717fcc5948