### PR TITLE
Load external SVG map and ensure responsive interaction

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -137,8 +137,8 @@ img,svg,video{max-width:100%;height:auto}
 .map-card svg{width:100%;height:auto;display:block}
 .tooltip{position:absolute;pointer-events:none;background:#ffffffeb;color:#111;border:1px solid #e5e7eb;border-radius:10px;padding:8px 10px;font-size:13px;transform:translate(-50%,-50%);min-width:160px;box-shadow:0 8px 24px rgba(0,0,0,.25)}
 .no-data{fill:#333 !important;stroke:#555;opacity:.6;cursor:not-allowed}
-[data-abbr]:hover,[data-abbr]:focus{outline:none;filter:brightness(1.1)}
-[data-abbr]:focus{stroke:#fff;stroke-width:1.5}
+[data-id]:hover,[data-id]:focus{outline:none;filter:brightness(1.1)}
+[data-id]:focus{stroke:#fff;stroke-width:1.5}
 
 /* CAN'T list */
 .list{margin:10px 0 14px;padding:0;list-style:none;border:1px solid #262a33;border-radius:14px;overflow:hidden;background:#0f1115}

--- a/index.html
+++ b/index.html
@@ -69,60 +69,7 @@
         </div>
 
         <div id="mapContainer" class="map-card">
-          <svg id="usMap" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 140" role="img" aria-labelledby="title"><title id="title">US State Map</title>
-  <g class="states">
-    <path data-abbr="AK" d="M1 121h18v18h-18z" />
-    <path data-abbr="AL" d="M121 81h18v18h-18z" />
-    <path data-abbr="AR" d="M81 61h18v18h-18z" />
-    <path data-abbr="AZ" d="M21 61h18v18h-18z" />
-    <path data-abbr="CA" d="M1 41h18v18h-18z" />
-    <path data-abbr="CO" d="M41 41h18v18h-18z" />
-    <path data-abbr="CT" d="M201 21h18v18h-18z" />
-    <path data-abbr="DE" d="M181 41h18v18h-18z" />
-    <path data-abbr="FL" d="M161 101h18v18h-18z" />
-    <path data-abbr="GA" d="M141 81h18v18h-18z" />
-    <path data-abbr="HI" d="M21 121h18v18h-18z" />
-    <path data-abbr="IA" d="M81 21h18v18h-18z" />
-    <path data-abbr="ID" d="M21 21h18v18h-18z" />
-    <path data-abbr="IL" d="M101 21h18v18h-18z" />
-    <path data-abbr="IN" d="M121 21h18v18h-18z" />
-    <path data-abbr="KS" d="M61 61h18v18h-18z" />
-    <path data-abbr="KY" d="M101 41h18v18h-18z" />
-    <path data-abbr="LA" d="M81 81h18v18h-18z" />
-    <path data-abbr="MA" d="M241 21h18v18h-18z" />
-    <path data-abbr="MD" d="M161 41h18v18h-18z" />
-    <path data-abbr="ME" d="M221 1h18v18h-18z" />
-    <path data-abbr="MI" d="M121 1h18v18h-18z" />
-    <path data-abbr="MN" d="M81 1h18v18h-18z" />
-    <path data-abbr="MO" d="M81 41h18v18h-18z" />
-    <path data-abbr="MS" d="M101 81h18v18h-18z" />
-    <path data-abbr="MT" d="M41 1h18v18h-18z" />
-    <path data-abbr="NC" d="M121 61h18v18h-18z" />
-    <path data-abbr="ND" d="M61 1h18v18h-18z" />
-    <path data-abbr="NE" d="M61 41h18v18h-18z" />
-    <path data-abbr="NH" d="M201 1h18v18h-18z" />
-    <path data-abbr="NJ" d="M181 21h18v18h-18z" />
-    <path data-abbr="NM" d="M41 81h18v18h-18z" />
-    <path data-abbr="NV" d="M21 41h18v18h-18z" />
-    <path data-abbr="NY" d="M161 1h18v18h-18z" />
-    <path data-abbr="OH" d="M141 21h18v18h-18z" />
-    <path data-abbr="OK" d="M61 81h18v18h-18z" />
-    <path data-abbr="OR" d="M1 21h18v18h-18z" />
-    <path data-abbr="PA" d="M161 21h18v18h-18z" />
-    <path data-abbr="RI" d="M221 21h18v18h-18z" />
-    <path data-abbr="SC" d="M141 61h18v18h-18z" />
-    <path data-abbr="SD" d="M61 21h18v18h-18z" />
-    <path data-abbr="TN" d="M101 61h18v18h-18z" />
-    <path data-abbr="TX" d="M61 101h18v18h-18z" />
-    <path data-abbr="UT" d="M41 61h18v18h-18z" />
-    <path data-abbr="VA" d="M141 41h18v18h-18z" />
-    <path data-abbr="VT" d="M181 1h18v18h-18z" />
-    <path data-abbr="WA" d="M1 1h18v18h-18z" />
-    <path data-abbr="WI" d="M101 1h18v18h-18z" />
-    <path data-abbr="WV" d="M121 41h18v18h-18z" />
-    <path data-abbr="WY" d="M41 21h18v18h-18z" />
-  </g></svg>
-
+          <div id="map"></div>
           <div id="tooltip" class="tooltip" hidden></div>
         </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -226,33 +226,44 @@ const spendColor = thresholdScale(SPEND_THRESHOLDS, COLORS);
 
 /***** GEOGRAPHIC MAP *****/
 (function wireGeoMap(){
-  const svg = document.getElementById("usMap");
-  if (!svg) return;
+  const container = document.getElementById("mapContainer");
   const tooltip = document.getElementById("tooltip");
-  if (!tooltip) return;
+  const holder = document.getElementById("map");
+  if (!container || !tooltip || !holder) return;
 
-  svg.querySelectorAll("[data-abbr]").forEach(path=>{
-    const abbr = path.getAttribute("data-abbr");
-    const val = NAEP[abbr];
-    if (val == null) path.classList.add("no-data");
-    else path.style.fill = profColor(val);
+  fetch("image/us-map.svg")
+    .then(r => r.text())
+    .then(svgText => {
+      holder.innerHTML = svgText;
+      const svg = holder.querySelector("svg");
+      if (!svg) return;
+      svg.id = "usMap";
+      svg.removeAttribute("width");
+      svg.removeAttribute("height");
 
-    path.addEventListener("mouseenter", e=> showTip(e, abbr, val));
-    path.addEventListener("mousemove", e=> moveTip(e));
-    path.addEventListener("mouseleave", ()=> { tooltip.hidden = true; });
-  });
+      svg.querySelectorAll("[data-id]").forEach(path => {
+        const abbr = path.getAttribute("data-id");
+        const val = NAEP[abbr];
+        if (val == null) path.classList.add("no-data");
+        else path.style.fill = profColor(val);
+
+        path.addEventListener("mouseenter", e => showTip(e, abbr, val));
+        path.addEventListener("mousemove", moveTip);
+        path.addEventListener("mouseleave", () => { tooltip.hidden = true; });
+      });
+    });
 
   function showTip(e, abbr, val){
     const name = STATE_NAMES[abbr] || abbr;
-    tooltip.innerHTML = `<div class="tip-title"><strong>${name} (${abbr})</strong></div>
-      <div>${val==null?'N/A':val.toFixed(1)+'%'} can read at grade level</div>`;
+    tooltip.innerHTML = `<div class="tip-title"><strong>${name} (${abbr})</strong></div>` +
+      `<div>${val==null?'N/A':val.toFixed(1)+'%'} can read at grade level</div>`;
     tooltip.hidden = false;
     moveTip(e);
   }
   function moveTip(e){
-    const container = document.getElementById("mapContainer").getBoundingClientRect();
-    const x = Math.max(12, Math.min(e.clientX - container.left + 12, container.width - 10));
-    const y = Math.max(12, Math.min(e.clientY - container.top - 14, container.height - 12));
+    const rect = container.getBoundingClientRect();
+    const x = Math.max(12, Math.min(e.clientX - rect.left + 12, rect.width - 10));
+    const y = Math.max(12, Math.min(e.clientY - rect.top - 14, rect.height - 12));
     tooltip.style.left = x + "px";
     tooltip.style.top = y + "px";
   }


### PR DESCRIPTION
## Summary
- Replace placeholder grid with container that loads `image/us-map.svg`
- Color states and show tooltips from dynamic SVG using `data-id`
- Update styles to target `[data-id]` and keep map responsive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689a808f7cb0832c900644819d10c014