### PR TITLE
Add underline animation and UI refinements

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -45,15 +45,14 @@ img,svg,video{max-width:100%;height:auto}
   position:absolute;
   left:0;
   right:0;
-  bottom:0;
-  height:.55em;
+  bottom:-4px;
+  height:3px;
   background:var(--accent);
   transform-origin:left;
   transform:scaleX(0);
-  border-radius:.25em;
-  z-index:-1;
+  border-radius:2px;
 }
-.animate-hl .hero__title .hl{ color:#111; }
+.animate-hl .hero__title .hl{ color:inherit; }
 .animate-hl .hero__title .hl .sweep{
   animation:hlSweep 1200ms cubic-bezier(.22,1,.36,1) 200ms both;
 }
@@ -64,7 +63,7 @@ img,svg,video{max-width:100%;height:auto}
   .hero__video{display:none}
   .section-title:after{animation:none}
   .animate-hl .hero__title .hl .sweep{animation:none;transform:scaleX(1)}
-  .animate-hl .hero__title .hl{color:#111}
+  .animate-hl .hero__title .hl{color:inherit}
 }
 
 /* Panels */

--- a/index.html
+++ b/index.html
@@ -45,10 +45,6 @@
               <li><span class="key key--cant"></span><strong>CAN'T</strong> read at grade level</li>
               <li><span class="key key--can"></span><strong>CAN</strong> read at grade level</li>
             </ul>
-            <div class="chips">
-              <div class="chip chip--cant"><strong>CAN'T:</strong> <span id="cantVal">68%</span></div>
-              <div class="chip"><strong>CAN:</strong> <span id="canVal">32%</span></div>
-            </div>
           </div>
 
           <!-- RIGHT: donut -->

--- a/js/app.js
+++ b/js/app.js
@@ -367,7 +367,7 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
     ul.innerHTML = "";
 
     // Spacer + fact
-    const TRIGGER = 0.7, TRAVEL = 1;
+    const TRIGGER = 0.7, TRAVEL = 0.6;
     let spacer = document.getElementById("spendSpacer");
     if (!spacer) {
       spacer = document.createElement("div");

--- a/js/app.js
+++ b/js/app.js
@@ -94,13 +94,14 @@ const spendColor = thresholdScale(SPEND_THRESHOLDS, COLORS);
 
   const canArc = make("circle",{cx,cy,r,fill:"none","stroke-width":th,"stroke-linecap":"butt",transform:`rotate(-90 ${cx} ${cy})`});
   canArc.style.stroke = NEUTRAL; canArc.style.opacity = "0.35";
-  canArc.setAttribute("stroke-dasharray", `${C} 0`);
+  canArc.setAttribute("stroke-dasharray", `${C}`);
+  canArc.setAttribute("stroke-dashoffset", "0");
   svg.appendChild(canArc);
 
   const cantArc = make("circle",{cx,cy,r,fill:"none","stroke-width":th,"stroke-linecap":"butt",transform:`rotate(-90 ${cx} ${cy})`});
   cantArc.style.stroke = ACCENT;
-  cantArc.setAttribute("stroke-dasharray", `${cantLen} ${C-cantLen}`);
-  cantArc.setAttribute("stroke-dashoffset", String(cantLen));
+  cantArc.setAttribute("stroke-dasharray", `${C}`);
+  cantArc.setAttribute("stroke-dashoffset", `${C}`);
   svg.appendChild(cantArc);
 
   const big = make("text",{x:cx,y:cy+6,"text-anchor":"middle","font-size":"38","font-weight":"800",fill:"#fff"}); big.textContent="0%";
@@ -109,14 +110,14 @@ const spendColor = thresholdScale(SPEND_THRESHOLDS, COLORS);
 
   function animate(){
     const reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduce){ cantArc.setAttribute("stroke-dashoffset","0"); big.textContent = cant + "%"; return; }
+    if (reduce){ cantArc.setAttribute("stroke-dashoffset", String(C - cantLen)); big.textContent = cant + "%"; return; }
     const dur = 2000; // slower
     const start = performance.now();
     const ease = t => 1 - Math.pow(1 - t, 3);
     function tick(now){
       const t = Math.min(1, (now - start)/dur);
       const p = ease(t);
-      cantArc.setAttribute("stroke-dashoffset", String(cantLen * (1 - p)));
+      cantArc.setAttribute("stroke-dashoffset", String(C - cantLen * p));
       big.textContent = Math.round(cant * p) + "%";
       if (t < 1) requestAnimationFrame(tick);
     }
@@ -190,12 +191,7 @@ const spendColor = thresholdScale(SPEND_THRESHOLDS, COLORS);
   ul.className="key-bullets";
   ul.innerHTML = '<li><span class="key key--cant"></span><strong>CAN\'T</strong> read at grade level</li>'+
                  '<li><span class="key key--can"></span><strong>CAN</strong> read at grade level</li>';
-  const chipsDiv = document.createElement("div");
-  chipsDiv.className="chips";
-  chipsDiv.innerHTML = `<div class="chip chip--cant"><strong>CAN'T:</strong> <span>${cant}%</span></div>
-                        <div class="chip"><strong>CAN:</strong> <span>${can}%</span></div>`;
   legendHost.appendChild(ul);
-  legendHost.appendChild(chipsDiv);
   left.appendChild(legendHost);
 
   // Animate on scroll (slower stagger)
@@ -256,7 +252,7 @@ const spendColor = thresholdScale(SPEND_THRESHOLDS, COLORS);
   function showTip(e, abbr, val){
     const name = STATE_NAMES[abbr] || abbr;
     tooltip.innerHTML = `<div class="tip-title"><strong>${name} (${abbr})</strong></div>` +
-      `<div>${val==null?'N/A':val.toFixed(1)+'%'} can read at grade level</div>`;
+      `<div>${val==null?'N/A':'Only '+val.toFixed(1)+'%'} can read at grade level</div>`;
     tooltip.hidden = false;
     moveTip(e);
   }
@@ -371,7 +367,7 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
     ul.innerHTML = "";
 
     // Spacer + fact
-    const TRIGGER = 0.7, TRAVEL = 0.5;
+    const TRIGGER = 0.7, TRAVEL = 1;
     let spacer = document.getElementById("spendSpacer");
     if (!spacer) {
       spacer = document.createElement("div");
@@ -507,7 +503,7 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
   // Compute duration based on content width (≈80px/sec)
   function setDuration(){
     const distance = track.scrollWidth;
-    const speed = 80; // px/sec
+    const speed = 120; // px/sec
     const dur = Math.max(20, Math.round((distance/2) / speed)); // seconds for half-track
     track.style.setProperty("--marquee-duration", `${dur}s`);
   }


### PR DESCRIPTION
## Summary
- animate red underline under the “can’t read” headline
- redraw national donut from gray base to 68% red fill
- simplify pictogram legend and remove CAN/CAN’T chips
- prefix state tooltips with “Only” and speed up book carousel
- expand scroll room for spending list bottom row

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689a861e2174832c943cfd5314a610cb