### PR TITLE
Use single ripped book overlay in hero header

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -30,14 +30,9 @@ img,svg,video{max-width:100%;height:auto}
 .hero__graph{width:100%;height:100%}
 .hero__graph-line{fill:none;stroke:#fff;stroke-width:2;stroke-dasharray:300;stroke-dashoffset:300;animation:drawGraph 6s linear forwards}
 @keyframes drawGraph{to{stroke-dashoffset:0}}
-.hero__book-half{position:absolute;top:0;bottom:0;width:50%;background-image:url('https://images.unsplash.com/photo-1512820790803-83ca734da794?auto=format&fit=crop&w=2000&q=80');background-size:200% 100%;background-repeat:no-repeat;z-index:2}
-.hero__book-half--left{left:0;background-position:0 0;transform-origin:right;animation:tearLeft 5s ease forwards}
-.hero__book-half--right{right:0;background-position:100% 0;transform-origin:left;animation:tearRight 5s ease forwards}
-@keyframes tearLeft{to{transform:translateX(-100%) rotate(-1deg)}}
-@keyframes tearRight{to{transform:translateX(100%) rotate(1deg)}}
-.hero__book-half::after{content:"";position:absolute;top:0;bottom:0;width:24px;background:url('https://i.imgur.com/2M4ppbl.png') center/cover no-repeat}
-.hero__book-half--left::after{right:-12px}
-.hero__book-half--right::after{left:-12px;transform:scaleX(-1)}
+.hero__book{position:absolute;inset:0;width:100%;background-image:url('https://images.unsplash.com/photo-1512820790803-83ca734da794?auto=format&fit=crop&w=2000&q=80');background-size:cover;background-position:center;background-repeat:no-repeat;z-index:2;animation:bookRip 5s ease forwards;transform-origin:left}
+.hero__book::after{content:"";position:absolute;top:0;bottom:0;right:-12px;width:24px;background:url('https://i.imgur.com/2M4ppbl.png') center/cover no-repeat}
+@keyframes bookRip{from{width:100%}to{width:50%}}
 .hero__scrim{position:absolute;inset:0;background:radial-gradient(1200px 500px at 50% 110%, rgba(0,0,0,.65), transparent 70%);z-index:3}
 .hero__content{position:relative;padding:72px 16px 48px;z-index:4}
 .eyebrow{letter-spacing:.12em;text-transform:uppercase;color:var(--muted);font-size:13px;margin:0 0 8px}
@@ -72,7 +67,7 @@ img,svg,video{max-width:100%;height:auto}
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce){
-  .hero__book-half{animation:none}
+  .hero__book{animation:none}
   .hero__graph-line{animation:none;stroke-dashoffset:0}
   .section-title:after{animation:none}
   .animate-hl .hero__title .hl .sweep{animation:none;transform:scaleX(1)}

--- a/index.html
+++ b/index.html
@@ -18,8 +18,7 @@
           <polyline class="hero__graph-line" points="0,10 20,25 40,45 60,65 80,82 100,90" />
         </svg>
       </div>
-      <div class="hero__book-half hero__book-half--left"></div>
-      <div class="hero__book-half hero__book-half--right"></div>
+      <div class="hero__book"></div>
     </div>
     <div class="hero__scrim"></div>
 


### PR DESCRIPTION
## Summary
- Replace two book-half elements with a single `.hero__book` overlay that rips to reveal header content.
- Add `bookRip` animation and reduced-motion fallback.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689aa14cc3d8832c8cf7ddfee99b0ba7