### PR TITLE
feat: add hero background video

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -25,6 +25,7 @@ img,svg,video{max-width:100%;height:auto}
   position:relative;min-height:58vh;display:flex;align-items:flex-end;overflow:hidden;
   background:#000;
 }
+.hero__video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;}
 .hero__visual{position:absolute;inset:0;overflow:hidden}
 .hero__reveal{position:absolute;inset:0;background:#5a0000;display:flex;align-items:center;justify-content:center;z-index:1}
 .hero__graph{width:100%;height:100%}

--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
 
   <!-- Hero / Header -->
   <header class="hero">
+    <video class="hero__video" autoplay muted loop playsinline aria-hidden="true">
+      <source src="image/paper%20rip.mp4" type="video/mp4">
+    </video>
     <div class="hero__visual" aria-hidden="true">
       <div class="hero__reveal">
         <svg class="hero__graph" viewBox="0 0 100 100" preserveAspectRatio="none">


### PR DESCRIPTION
## Summary
- add looping background video to hero section
- style video to cover header without affecting existing content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ab51235e0832c86d619bdbe19e0cf