### PR TITLE
Replace hero gradient with animated SVG

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -30,24 +30,15 @@ img,svg,video{max-width:100%;height:auto}
 @keyframes bgShift{0%{background-position:0% 50%}50%{background-position:100% 50%}100%{background-position:0% 50%}}
 
 /* Hero with subtle animated background */
+
+/* Hero with animated SVG background */
 .hero{
   position: relative;
   min-height: 48vh; /* reduced from 60vh */
   display: flex;
   align-items: flex-end;
   overflow: hidden;
-
-  /* Softer gradient + subtle motion */
-  background: linear-gradient(180deg, #9b1115 0%, #7b0d12 60%, #640a0f 100%);
-  background-size: 200% 200%;
-  animation: heroBgShift 40s ease-in-out infinite;
-}
-
-/* slow, gentle panning */
-@keyframes heroBgShift {
-  0%   { background-position: 0% 0%; }
-  50%  { background-position: 100% 100%; }
-  100% { background-position: 0% 0%; }
+  background: var(--bg);
 }
 
 /* Subtle vignette to boost text contrast */
@@ -276,3 +267,15 @@ img,svg,video{max-width:100%;height:auto}
 
 /* SR-only */
 .sr-only{position:absolute !important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+
+/* Hero SVG background */
+.hero .hero-bg{
+  height:140%;
+  display:block;
+  position:absolute;
+  left:0;
+  top:-100px;
+  filter:hue-rotate(172deg);
+  z-index:1;
+  pointer-events:none;
+}

--- a/image/hero-bg.svg
+++ b/image/hero-bg.svg
@@ -1,0 +1,260 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2450.7 1343.9" xml:space="preserve">
+<style type="text/css">
+.st0{opacity:0.2;fill:#6EBECE;}
+.st1{opacity:0.2;fill:#04738A;}
+.st2{opacity:0.2;fill:#03496A;}
+.st3{opacity:0.2;fill:#0F97A1;}
+.st4{opacity:0.2;fill:#10596B;}
+.st5{opacity:0.2;fill:#0E5767;}
+.st6{opacity:0.5;fill:#46C1C6;}
+.st7{opacity:0.5;fill:#6AAECC;}
+.st8{opacity:0.2;fill:none;stroke:#24898E;stroke-miterlimit:10;}
+.st9{opacity:0.2;fill:#06546F;}
+.st10{opacity:0.2;fill:#3D9FBE;}
+.st11{opacity:0.2;fill:#064C6A;}
+.st12{opacity:0.2;fill:#047080;}
+.st13{opacity:0.2;fill:#0C638B;}
+.st14{opacity:0.5;fill:#106068;}
+.st15{opacity:0.5;fill:#1A737C;}
+.st16{opacity:0.5;fill:#1A8799;}
+.st17{opacity:0.5;fill:#1A848E;}
+.st18{opacity:0.5;fill:#5FC6C7;}
+.st19{opacity:0.5;fill:#0F5C63;}
+.st20{opacity:0.5;fill:#2694A0;}
+.st21{opacity:0.5;fill:#0A6481;}
+.st22{opacity:0.5;fill:#57B9CF;}
+.st23{opacity:0.5;fill:#0B526C;}
+.st24{opacity:0.5;fill:#0F7F8A;}
+.st25{opacity:0.5;fill:#11636C;}
+.st26{opacity:0.5;fill:#0B8898;}
+.st27{opacity:0.2;fill:#0B676A;}
+.st28{opacity:5.000000e-02;fill:none;stroke:#24898E;stroke-miterlimit:10;}
+.st29{opacity:0.5;fill:#208899;}
+.st30{opacity:0.5;fill:#279AA6;}
+.st31{opacity:0.5;fill:#167383;}
+.st32{opacity:0.5;fill:#2A9AA6;}
+.st33{opacity:0.5;fill:#1C8E78;}
+.st34{opacity:0.5;fill:#106068;}
+.st35{opacity:0.5;fill:#1A737C;}
+.st36{opacity:0.5;fill:#1A8799;}
+.st37{opacity:0.5;fill:#5FC6C7;}
+.st38{opacity:0.5;fill:#1A848E;}
+.st39{opacity:0.5;fill:#208899;}
+.st40{opacity:0.5;fill:#279AA6;}
+.st41{opacity:0.5;fill:#0F5C63;}
+.st42{opacity:0.5;fill:#2694A0;}
+.st43{opacity:0.5;fill:#167383;}
+.st44{opacity:0.5;fill:#2A9AA6;}
+.st45{opacity:0.5;fill:#1C8E78;}
+.st46{opacity:0.5;fill:#137260;}
+.st47{opacity:0.3;fill:#6EBECE;}
+.st48{opacity:0.3;fill:#04738A;}
+.st49{opacity:0.3;fill:#03496A;}
+.st50{opacity:0.5;fill:#0A6481;}
+.st51{opacity:0.5;fill:#57B9CF;}
+.st52{opacity:0.5;fill:#45B3C5;}
+.st53{opacity:0.5;fill:#0B526C;}
+.st54{opacity:0.5;fill:#0F7F8A;}
+.st55{opacity:0.5;fill:#11636C;}
+.st56{opacity:0.5;fill:#0B8898;}
+.st57{opacity:0.3;fill:#0B676A;}
+.st58{opacity:0.3;fill:#0F97A1;}
+.st59{opacity:0.3;fill:#10596B;}
+.st60{opacity:0.3;fill:#0E5767;}
+.st61{opacity:0.3;fill:#64BFBF;}
+.st62{opacity:0.3;fill:#2B8383;}
+.st63{opacity:0.3;fill:#46C1C6;}
+.st64{opacity:0.3;fill:#206462;}
+.st65{opacity:0.5;fill:#46C1C6;}
+.st66{opacity:0.5;fill:#6AAECC;}
+.st67{opacity:0.3;fill:none;stroke:#24898E;stroke-miterlimit:10;}
+.st68{opacity:5.000000e-02;fill:none;stroke:#24898E;stroke-miterlimit:10;}
+.st69{opacity:0.3;fill:#06546F;}
+.st70{opacity:0.3;fill:#3D9FBE;}
+.st71{opacity:0.3;fill:#064C6A;}
+.st72{opacity:0.3;fill:#047080;}
+.st73{opacity:0.3;fill:#0C638B;}
+.st74{opacity:0.35;fill:#1A737C;}
+.st75{opacity:0.3;fill:#2E8887;}
+.st76{opacity:0.3;fill:#08838B;}
+.st77{opacity:0.34;fill:#42B0A3;}
+.st78{opacity:0.5;fill:#128172;}
+.st79{opacity:0.35;fill:none;stroke:#24898E;stroke-miterlimit:10;}
+.st80{opacity:0.5;fill:#24898E;}
+.st81{opacity:0.3;fill:#6CC0BA;}
+.st82{opacity:0.3;fill:#3896BA;}
+.st83{opacity:0.5;fill:#086A73;}
+.st84{opacity:0.35;fill:#0781A0;}
+.st85{opacity:0.33;fill:none;stroke:#24898E;stroke-miterlimit:10;}
+.st86{opacity:0.3;fill:#0A6D75;}
+.st87{opacity:0.3;fill:#0C8270;}
+.st88{opacity:0.3;fill:#4DB5B9;}
+.st89{opacity:0.3;fill:#1A737C;}
+.st90{opacity:0.5;fill:#0CA181;}
+.st91{opacity:0.35;fill:#328488;}
+.st92{opacity:0.34;fill:#06938E;}
+.st93{opacity:0.37;fill:#105756;}
+
+#top .st48,
+#top .st52,
+#top .st50{animation:drift-right-up 80s alternate;}
+#top .st33,
+#top .st51{animation:drift-right-up 75s alternate;}
+#top .st49,
+#top .st42{animation:drift-right-up 65s alternate;}
+
+#bottom .st11,
+#bottom .st56{animation:drift-down 70s alternate;}
+#bottom .st53,
+#bottom .st54{animation:drift-right 195s alternate;}
+#bottom .st55,
+#bottom .st36,
+#bottom .st33{animation:drift-down 115s alternate;}
+#bottom .st51{animation:drift-down-right 105s alternate;}
+
+#nearright .st40,
+#nearright .st43,
+#nearright .st33{animation:drift-right 115s;}
+#nearright .st41,
+#nearright .st44{animation:drift-right-up 105s;}
+#nearright .st42,
+#nearright .st45,
+#nearright .st46,
+#nearright .st55,
+#nearright .st47{animation:drift-right 135s;}
+
+#farright .st54,
+#farright .st58,
+#farright .st59{animation:drift-right 55s;}
+#farright .st57,
+#farright .st51{animation:drift-right-up 40s;}
+
+@keyframes drift-right{100%{transform:translate(2000px,-20px);}}
+@keyframes drift-right-up{100%{transform:translate(2000px,-250px);}}
+@keyframes drift-up{100%{transform:translate(10px,-1450px);}}
+@keyframes drift-up-right{100%{transform:translate(175px,-1550px);}}
+@keyframes drift-down{100%{transform:translate(2000px,1220px);}}
+@keyframes drift-down-right{100%{transform:translate(1450px,320px);}}
+</style>
+
+<g id="base0">
+<polygon class="st0" points="-41.1,715 -169.8,715.6 -101.5,618.1"/>
+<polygon class="st1" points="2.6,563.5 -41.1,715 -101.5,618.1"/>
+<polygon class="st2" points="-18.6,372.3 -135.4,405.1 2.6,563.5"/>
+<polygon class="st3" points="-41.1,715 -103.6,794.2 -38,846.5"/>
+<polygon class="st4" points="-169.8,715.6 -103.6,794.2 -41.1,715"/>
+<polygon class="st5" points="-136,859 -137.2,807.7 -103.6,794.2"/>
+<polygon class="st6" points="-136,859 -103.6,794.2 -38,846.5"/>
+<polygon class="st7" points="-153.5,499 -135.4,405.1 2.6,563.5"/>
+<polygon class="st8" points="-41.1,715 -169.8,715.6 -101.5,618.1"/>
+<polygon class="st8" points="-257.5,671 -236.4,569.2 -101.5,618.1"/>
+<polygon class="st8" points="-153.5,499 -101.5,618.1 2.6,563.5"/>
+<polygon class="st8" points="-236.4,569.2 -101.5,618.1 -153.5,499"/>
+<polygon class="st8" points="-257.5,671 -169.8,715.6 -101.5,618.1"/>
+<polygon class="st8" points="2.6,563.5 -41.1,715 -101.5,618.1"/>
+<polygon class="st8" points="-18.6,372.3 -135.4,405.1 2.6,563.5"/>
+<polygon class="st8" points="-41.1,715 -103.6,794.2 -38,846.5"/>
+<polygon class="st8" points="-169.8,715.6 -103.6,794.2 -41.1,715"/>
+<polygon class="st8" points="-169.8,715.6 -137.2,807.7 -103.6,794.2"/>
+<polygon class="st8" points="-136,859 -137.2,807.7 -103.6,794.2"/>
+<polygon class="st9" points="-153.5,499 -101.5,618.1 2.6,563.5"/>
+<polygon class="st10" points="-257.5,671 -169.8,715.6 -101.5,618.1"/>
+<polygon class="st11" points="-236.4,569.2 -101.5,618.1 -153.5,499"/>
+<polygon class="st12" points="-169.8,715.6 -137.2,807.7 -103.6,794.2"/>
+<polygon class="st13" points="-257.5,671 -236.4,569.2 -101.5,618.1"/>
+</g>
+<g id="base1">
+<polygon class="st14" points="30.2,984 -37.8,844.3 77.8,774.6"/>
+<polygon class="st15" points="50.9,713.1 -41.1,715 1.8,568.4"/>
+<polygon class="st16" points="77.8,774.6 144.2,896.7 30.2,984"/>
+<polygon class="st15" points="235.7,825.7 77.8,774.6 180.9,746.7"/>
+<polygon class="st17" points="77.8,774.6 144.2,896.7 235.7,825.7"/>
+<polygon class="st18" points="77.8,774.6 50.9,713.1 180.9,746.7"/>
+<polygon class="st17" points="-37.6,843.7 -41.1,715 50.9,713.1"/>
+<polygon class="st19" points="97,592.1 50.9,713.1 0,563"/>
+<polygon class="st20" points="-37.8,844.3 77.8,774.6 50.9,713.1"/>
+<polyline class="st15" points="180.9,746.7 97,592.1 50.9,713.1"/>
+<polygon class="st21" points="129.1,515.9 2.6,563.5 -18.6,372.3"/>
+<polygon class="st22" points="97,592.1 2.6,563.5 129.1,515.9"/>
+<polygon class="st23" points="133.9,390.3 -18.6,372.3 129.1,515.9"/>
+<polygon class="st27" points="-38,846.5 -136,859 29.9,985.1"/>
+<polygon class="st28" points="129.1,515.9 2.6,563.5 -18.6,372.3"/>
+<polygon class="st8" points="97,592.1 2.6,563.5 129.1,515.9"/>
+<polygon class="st28" points="133.9,390.3 -18.6,372.3 129.1,515.9"/>
+<polygon class="st8" points="-38,846.5 -136,859 29.9,985.1"/>
+</g>
+<g id="base2">
+<polygon class="st24" points="260,503.4 258.2,428.6 129.1,515.9"/>
+<polygon class="st25" points="133.9,390.3 284.8,312.6 129.1,515.9"/>
+<polygon class="st26" points="258.2,428.6 284.8,312.6 129.1,515.9"/>
+<polygon class="st18" points="268,866 85.4,941.7 235.7,825.7"/>
+<polygon class="st29" points="265.7,770.1 235.7,825.7 294.4,824.3"/>
+<polygon class="st30" points="268,866 294.4,824.3 235.7,825.7"/>
+<polygon class="st19" points="265.7,770.1 180.9,746.7 235.7,825.7"/>
+<polygon class="st18" points="387.1,605.9 180.9,746.7 265.7,770.1"/>
+<polygon class="st16" points="97,592.1 180.9,746.7 387.1,605.9"/>
+<polygon class="st31" points="259,504.2 99.1,592.2 387.1,605.9"/>
+<polyline class="st32" points="387.1,605.9 414.4,684.9 265.7,770.1 387.1,605.9"/>
+<polygon class="st19" points="411.9,576.7 387.1,605.9 257.4,502.9"/>
+<polygon class="st33" points="332.3,989.6 243.3,1034.5 299.9,946.3"/>
+<polygon class="st34" points="396.4,887 332.3,989.6 299.9,946.3"/>
+<polygon class="st29" points="294.4,824.3 299.9,946.3 396.4,887"/>
+<polygon class="st34" points="86.1,941.7 299.9,946.3 268,866"/>
+<polygon class="st33" points="299.9,946.3 268,866 294.4,824.3"/>
+<polygon class="st35" points="258.5,504.1 129.1,515.9 97.7,592"/>
+<polygon class="st36" points="396.4,887 295.4,824.3 469.3,825.6"/>
+<polygon class="st37" points="265.7,770.1 294.4,824.3 469.3,825.6"/>
+<polygon class="st38" points="496.7,906.4 396.4,887 469.3,825.6"/>
+<polygon class="st39" points="396.4,887 474,1022.1 332.3,989.6"/>
+<polygon class="st8" points="258.5,504.1 129.1,515.9 97.7,592"/>
+<polygon class="st28" points="260,503.4 258.2,428.6 129.1,515.9"/>
+<polygon class="st28" points="133.9,390.3 284.8,312.6 129.1,515.9"/>
+<polygon class="st28" points="258.2,428.6 284.8,312.6 129.1,515.9"/>
+<polygon class="st8" points="396.4,887 295.4,824.3 469.3,825.6"/>
+<polygon class="st8" points="265.7,770.1 294.4,824.3 469.3,825.6"/>
+<polygon class="st8" points="496.7,906.4 396.4,887 469.3,825.6"/>
+<polygon class="st8" points="396.4,887 474,1022.1 332.3,989.6"/>
+</g>
+<g id="nearright">
+<polygon class="st40" points="289.8,766.6 493.5,822.1 438.6,681.4"/>
+<polygon class="st41" points="513.6,915.4 500.3,1032.6 412,904.2"/>
+<polygon class="st42" points="271.9,503 396.3,445.6 270.1,428.2"/>
+<polygon class="st43" points="413.9,447.3 441.3,578 334.6,527"/>
+<polygon class="st44" points="420.4,685.1 417.8,576.9 393.1,606"/>
+<polygon class="st45" points="305.1,764.2 508.8,819.6 453.9,679"/>
+<polygon class="st8" points="513.6,915.4 500.3,1032.6 412,904.2"/>
+<polyline class="st46" points="399.3,440.4 273,422.9 299.6,307 399.3,440.4"/>
+<polygon class="st8" points="271.9,503 396.3,445.6 270.1,428.2"/>
+<polyline class="st8" points="271.9,503 317,525.4 396.3,445.6"/>
+<polyline class="st47" points="271.9,503 317,525.4 396.3,445.6"/>
+<polygon class="st8" points="411.9,447.6 439.3,578.3 332.6,527.4"/>
+</g>
+<g id="top">
+<polygon class="st48" points="-22.5,335.5 103.7,234.5 130.1,353.5"/>
+<polygon class="st49" points="442.7,423.3 463.2,262.8 343.1,289.9"/>
+<polygon class="st8" points="-22.5,335.5 103.7,234.5 130.1,353.5"/>
+<polygon class="st50" points="145.1,321.3 118.8,202.3 296,243.6"/>
+<polygon class="st51" points="148.3,311.4 121.9,192.3 299.1,233.7"/>
+<polyline class="st52" points="469.9,251.7 347.9,214.6 392.4,104.2 469.9,251.7"/>
+</g>
+<g id="bottom">
+<polygon class="st53" points="23.4,1031.5 236.7,1080.9 79.6,988.1"/>
+<polygon class="st8" points="27.3,1033 240.6,1082.3 83.5,989.5"/>
+<polygon class="st54" points="480.9,1064.7 448.5,1160 397.7,1123.9"/>
+<polygon class="st54" points="124.2,1235.6 8.6,1188 77.9,1262.3"/>
+<polygon class="st51" points="142,1232.4 26.4,1184.8 95.7,1259.1"/>
+<polygon class="st55" points="142,1101.2 202.5,1157.7 119.3,1216.9"/>
+<polygon class="st51" points="150.5,1086.7 211.1,1143.2 127.9,1202.5"/>
+<polygon class="st8" points="482.9,1054.7 450.5,1150 399.7,1113.9"/>
+<polygon class="st56" points="287.8,957.3 74.1,952.7 231.2,1045.5"/>
+</g>
+<g id="farright">
+<polygon class="st54" points="684.3,737.9 563.7,770.6 664,787.3"/>
+<polygon class="st57" points="693.5,532.6 869,640.4 748.4,673.2"/>
+<polygon class="st58" points="481.5,490.4 574.2,431.7 487.1,623.8"/>
+<polygon class="st59" points="527.8,314.7 609.7,241.6 548.4,154.2"/>
+<polygon class="st51" points="695.7,736.1 575.1,768.8 675.4,785.4"/>
+<polygon class="st51" points="684.5,551.8 860,659.7 739.4,692.4"/>
+<polygon class="st51" points="517.3,483.1 610.1,424.4 522.9,616.5"/>
+</g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 
   <!-- Hero / Header -->
   <header class="hero">
+    <img src="image/hero-bg.svg" class="hero-bg" alt="" aria-hidden="true" />
     <div class="container hero__content">
       <h1 class="eyebrow">NATIONAL CRISIS</h1>
       <!-- keep the phrase “can't read” so the header highlight runs -->


### PR DESCRIPTION
## Summary
- replace gradient hero backdrop with animated SVG
- adjust palette via hue rotation filter for color match

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a13bc004808333835508cc2f151968