### PR TITLE
Slow down national snapshot animations and trigger earlier list motion

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -183,8 +183,8 @@ img,svg,video{max-width:100%;height:auto}
 .pictogram-human .human.is-cant{color:var(--accent)}
 
 /* slower animations */
-.pictogram-human .human.pop{animation:picPop 650ms cubic-bezier(.22,1,.36,1) both}
-.pictogram-human .human.fade{animation:picFade 600ms ease-out both}
+.pictogram-human .human.pop{animation:picPop 1000ms cubic-bezier(.22,1,.36,1) both}
+.pictogram-human .human.fade{animation:picFade 900ms ease-out both}
 @keyframes picPop{from{opacity:.15;transform:translateY(8px) scale(.68)}to{opacity:1;transform:none}}
 @keyframes picFade{from{opacity:0}to{opacity:.95}}
 

--- a/js/app.js
+++ b/js/app.js
@@ -111,7 +111,7 @@ const spendColor = thresholdScale(SPEND_THRESHOLDS, COLORS);
   function animate(){
     const reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (reduce){ cantArc.setAttribute("stroke-dashoffset", String(C - cantLen)); big.textContent = cant + "%"; return; }
-    const dur = 2000; // slower
+    const dur = 4000; // slower
     const start = performance.now();
     const ease = t => 1 - Math.pow(1 - t, 3);
     function tick(now){
@@ -199,7 +199,7 @@ const spendColor = thresholdScale(SPEND_THRESHOLDS, COLORS);
   const cells = pic.querySelectorAll(".human");
   function runAnim(){
     cells.forEach((cell, j)=>{
-      const delay = j * 24; // slower stagger
+      const delay = j * 40; // slower stagger
       if (reduce){
         cell.style.animation = "none";
         cell.style.color = cell.classList.contains("is-cant") ? ACCENT : NEUTRAL;
@@ -314,7 +314,7 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
     const visible = showAll ? items : items.slice(0,5);
     list.innerHTML = "";
 
-    const scrub = makeTopLineScrubber(0.7, 0.5);
+    const scrub = makeTopLineScrubber(0.8, 0.5);
 
     visible.forEach(d=>{
       const li = document.createElement("li");
@@ -367,7 +367,7 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
     ul.innerHTML = "";
 
     // Spacer + fact
-    const TRIGGER = 0.7, TRAVEL = 0.6;
+    const TRIGGER = 0.8, TRAVEL = 0.6;
     let spacer = document.getElementById("spendSpacer");
     if (!spacer) {
       spacer = document.createElement("div");


### PR DESCRIPTION
## Summary
- Slow national donut animation to 4s and stagger pictograph figures with longer delays
- Start ranked states and spending animations sooner with lower scroll triggers
- Lengthen pictograph animation durations for smoother entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a13f7bde6483339692ca2773d0c264