### PR TITLE
Ensure only one story video plays at a time with sound

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
           <!-- Story 1 -->
           <article id="story-1" class="stories-card" aria-label="Story 1" data-bg="">
             <div class="stories-media">
-              <video playsinline autoplay loop muted preload="auto"
+              <video playsinline loop preload="auto"
                      poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>Olivia_final.mp4</text></svg>">
                 <source src="image/Olivia_final.mp4" type="video/mp4">
               </video>
@@ -83,7 +83,7 @@
           <!-- Story 2 -->
           <article id="story-2" class="stories-card" aria-label="Story 2" data-bg="">
             <div class="stories-media">
-              <video playsinline autoplay loop muted preload="auto"
+              <video playsinline loop preload="auto"
                      poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>James_final.mp4</text></svg>">
                 <source src="image/James_final.mp4" type="video/mp4">
               </video>
@@ -97,7 +97,7 @@
           <!-- Story 3 -->
           <article id="story-3" class="stories-card" aria-label="Story 3" data-bg="">
             <div class="stories-media">
-              <video playsinline autoplay loop muted preload="auto"
+              <video playsinline loop preload="auto"
                      poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>Ava_final.mp4</text></svg>">
                 <source src="image/Ava_final.mp4" type="video/mp4">
               </video>

--- a/js/app.js
+++ b/js/app.js
@@ -574,6 +574,12 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
 
   // Observe cards for in-view + autoplay/pause + portrait swap
   const cards = wrap.querySelectorAll('.stories-card');
+  const videos = wrap.querySelectorAll('.stories-card video');
+  videos.forEach(v => {
+    v.addEventListener('play', () => {
+      videos.forEach(o => { if (o !== v) o.pause(); });
+    });
+  });
   let lastBG = '';
   const io = new IntersectionObserver((entries) => {
     entries.forEach(e => {
@@ -595,7 +601,12 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
           lastBG = url;
         }
 
-        if (v) { try { v.play(); } catch(_){} }
+        if (v) {
+          try {
+            v.muted = false;
+            v.play();
+          } catch(_){ }
+        }
       } else {
         e.target.classList.remove('in-view');
         if (v) { try { v.pause(); } catch(_){} }


### PR DESCRIPTION
## Summary
- Allow story videos to play with audio by removing muted/autoplay attributes.
- Pause other story videos whenever one starts playing.
- Unmute and play the in-view video when it enters the viewport.

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a26fe31f648333adcbabef3fae9ec4