### PR TITLE
Enable playback controls for story videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
           <!-- Story 1 -->
           <article id="story-1" class="stories-card" aria-label="Story 1" data-bg="image/Oliviaprofile.png">
             <div class="stories-media">
-              <video playsinline loop preload="auto"
+                <video controls playsinline loop preload="auto"
                      poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>Olivia_final.mp4</text></svg>">
                 <source src="image/Olivia_final.mp4" type="video/mp4">
               </video>
@@ -83,7 +83,7 @@
           <!-- Story 2 -->
           <article id="story-2" class="stories-card" aria-label="Story 2" data-bg="image/Jamesprofile.png">
             <div class="stories-media">
-              <video playsinline loop preload="auto"
+                <video controls playsinline loop preload="auto"
                      poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>James_final.mp4</text></svg>">
                 <source src="image/James_final.mp4" type="video/mp4">
               </video>
@@ -97,7 +97,7 @@
           <!-- Story 3 -->
           <article id="story-3" class="stories-card" aria-label="Story 3" data-bg="image/Avaprofile.png">
             <div class="stories-media">
-              <video playsinline loop preload="auto"
+                <video controls playsinline loop preload="auto"
                      poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>Ava_final.mp4</text></svg>">
                 <source src="image/Ava_final.mp4" type="video/mp4">
               </video>


### PR DESCRIPTION
## Summary
- add default playback controls to Olivia, James, and Ava story videos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a277adf0d483338411cffd82e39bcd