### PR TITLE
Display initial video frames by removing placeholder posters

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,8 +69,7 @@
           <!-- Story 1 -->
           <article id="story-1" class="stories-card" aria-label="Story 1" data-bg="image/Oliviaprofile.png">
             <div class="stories-media">
-                <video controls playsinline loop preload="auto"
-                     poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>Olivia_final.mp4</text></svg>">
+                <video controls playsinline loop preload="auto">
                 <source src="image/Olivia_final.mp4" type="video/mp4">
               </video>
             </div>
@@ -83,8 +82,7 @@
           <!-- Story 2 -->
           <article id="story-2" class="stories-card" aria-label="Story 2" data-bg="image/Jamesprofile.png">
             <div class="stories-media">
-                <video controls playsinline loop preload="auto"
-                     poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>James_final.mp4</text></svg>">
+                <video controls playsinline loop preload="auto">
                 <source src="image/James_final.mp4" type="video/mp4">
               </video>
             </div>
@@ -97,8 +95,7 @@
           <!-- Story 3 -->
           <article id="story-3" class="stories-card" aria-label="Story 3" data-bg="image/Avaprofile.png">
             <div class="stories-media">
-                <video controls playsinline loop preload="auto"
-                     poster="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='450'><rect fill='%231f2937' width='100%' height='100%'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial' font-size='24'>Ava_final.mp4</text></svg>">
+                <video controls playsinline loop preload="auto">
                 <source src="image/Ava_final.mp4" type="video/mp4">
               </video>
             </div>


### PR DESCRIPTION
## Summary
- Remove inline SVG poster placeholders from story videos so each video shows its first frame before playback.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a27d7c4764833380043cb5b3dfd421