### PR TITLE
Add central play overlay to story videos

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -336,6 +336,20 @@ img,svg,video{max-width:100%;height:auto}
   overflow:clip;position:relative;box-shadow:var(--stories-shadow);
 }
 .stories-media{position:relative;aspect-ratio:16/9;background:#000;}
+.stories-play{
+  position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);
+  width:80px;height:80px;border-radius:50%;
+  background:rgba(0,0,0,.6);border:none;cursor:pointer;
+  display:flex;align-items:center;justify-content:center;
+}
+.stories-play::before{
+  content:"";display:block;
+  border-left:26px solid #fff;
+  border-top:16px solid transparent;
+  border-bottom:16px solid transparent;
+  margin-left:4px;
+}
+.stories-media.playing .stories-play{display:none;}
 .stories-card video{
   width:100%;height:100%;object-fit:cover;display:block;
   transform:scale(1.01) translateY(0);

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
                 <video controls playsinline loop preload="auto">
                 <source src="image/Olivia_final.mp4" type="video/mp4">
               </video>
+              <button class="stories-play" aria-label="Play video"></button>
             </div>
             <div class="stories-content">
               <h3>Story — The Teacher I Didn’t Become</h3>
@@ -85,6 +86,7 @@
                 <video controls playsinline loop preload="auto">
                 <source src="image/James_final.mp4" type="video/mp4">
               </video>
+              <button class="stories-play" aria-label="Play video"></button>
             </div>
             <div class="stories-content">
               <h3>Story — Stars &amp; Wonder</h3>
@@ -98,6 +100,7 @@
                 <video controls playsinline loop preload="auto">
                 <source src="image/Ava_final.mp4" type="video/mp4">
               </video>
+              <button class="stories-play" aria-label="Play video"></button>
             </div>
             <div class="stories-content">
               <h3>Story — The Secret</h3>

--- a/js/app.js
+++ b/js/app.js
@@ -576,8 +576,17 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
   const cards = wrap.querySelectorAll('.stories-card');
   const videos = wrap.querySelectorAll('.stories-card video');
   videos.forEach(v => {
+    const media = v.closest('.stories-media');
+    const btn = media && media.querySelector('.stories-play');
+    if (btn) {
+      btn.addEventListener('click', () => { v.play(); });
+    }
     v.addEventListener('play', () => {
       videos.forEach(o => { if (o !== v) o.pause(); });
+      media && media.classList.add('playing');
+    });
+    v.addEventListener('pause', () => {
+      media && media.classList.remove('playing');
     });
   });
   let lastBG = '';


### PR DESCRIPTION
## Summary
- overlay a large play button on each story video
- hide the button while videos are playing and show it when paused

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a2819d731c8333b7fc29316bbcd2af