### PR TITLE
Improve mobile layout and button placement

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -189,6 +189,7 @@ img,svg,video{max-width:100%;height:auto}
 @keyframes picFade{from{opacity:0}to{opacity:.95}}
 
 @media (max-width:900px){.pictogram-human{max-width:520px}}
+@media (max-width:600px){.pictogram-human{max-width:none;--fig:calc((100% - (9 * var(--gap))) / 10);}}
 
 /* Donut viz */
 .nx-viz{display:flex;justify-content:center;align-items:center;min-height:260px}
@@ -350,6 +351,7 @@ img,svg,video{max-width:100%;height:auto}
   margin-left:4px;
 }
 .stories-media.playing .stories-play{display:none;}
+@media (max-width:900px){.stories-play{display:none;}}
 .stories-card video{
   width:100%;height:100%;object-fit:cover;display:block;
   transform:scale(1.01) translateY(0);

--- a/js/app.js
+++ b/js/app.js
@@ -387,7 +387,7 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
             <span id="eduBigNumber" style="font-size:clamp(40px,7vw,96px);color:#a50f15;"></span>
           </div>
         </div>`;
-      ul.parentNode.insertBefore(spacer, ul.nextSibling);
+      ul.parentNode.insertBefore(spacer, btn.parentNode);
     }
     function sizeSpacer(){
       const vh = window.innerHeight || document.documentElement.clientHeight;


### PR DESCRIPTION
## Summary
- Hide video overlay play buttons on small screens
- Make Grade 4 pictogram fill mobile width
- Position spending "View More" button below the big number counter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a0e0f4e083339b155d986c17d584