### PR TITLE
Fix pictogram responsiveness and adjust View More button position

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -188,8 +188,15 @@ img,svg,video{max-width:100%;height:auto}
 @keyframes picPop{from{opacity:.15;transform:translateY(8px) scale(.68)}to{opacity:1;transform:none}}
 @keyframes picFade{from{opacity:0}to{opacity:.95}}
 
-@media (max-width:900px){.pictogram-human{max-width:520px}}
-@media (max-width:600px){.pictogram-human{max-width:none;--fig:calc((100% - (9 * var(--gap))) / 10);}}
+@media (max-width:900px){
+  .pictogram-human{
+    max-width:520px;
+    --fig:calc((100% - (9 * var(--gap))) / 10);
+  }
+}
+@media (max-width:600px){
+  .pictogram-human{max-width:none}
+}
 
 /* Donut viz */
 .nx-viz{display:flex;justify-content:center;align-items:center;min-height:260px}

--- a/js/app.js
+++ b/js/app.js
@@ -387,7 +387,7 @@ function makeTopLineScrubber(topRatio = 0.7, travelRatio = 0.5) {
             <span id="eduBigNumber" style="font-size:clamp(40px,7vw,96px);color:#a50f15;"></span>
           </div>
         </div>`;
-      ul.parentNode.insertBefore(spacer, btn.parentNode);
+      ul.parentNode.insertBefore(spacer, btn.parentNode.nextElementSibling);
     }
     function sizeSpacer(){
       const vh = window.innerHeight || document.documentElement.clientHeight;


### PR DESCRIPTION
## Summary
- ensure the stick-figure pictogram scales to full width on tablets and phones
- place "View More" button above the U.S. spending counter

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a713bd808333be523add8cc6185d